### PR TITLE
Fix tag-related bug in 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	// You may need to force-disable transitiveness on them.
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/calio.accesswidener")
+}
+
 processResources {
 	inputs.property "version", project.version
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.13.3
 
 # Mod Properties
-	mod_version = 1.5.0
+	mod_version = 1.5.1
 	maven_group = com.github.apace100
 	archives_base_name = Calio-1.18.2
 

--- a/src/main/resources/calio.accesswidener
+++ b/src/main/resources/calio.accesswidener
@@ -1,0 +1,6 @@
+accessWidener   v1  named
+
+accessible class net/minecraft/recipe/Ingredient$Entry
+accessible method net/minecraft/recipe/Ingredient$StackEntry <init> (Lnet/minecraft/item/ItemStack;)V
+accessible method net/minecraft/recipe/Ingredient$TagEntry <init> (Lnet/minecraft/tag/TagKey;)V
+accessible method net/minecraft/recipe/Ingredient ofEntries (Ljava/util/stream/Stream;)Lnet/minecraft/recipe/Ingredient;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,6 +34,8 @@
     }
   },
 
+  "accessWidener": "calio.accesswidener",
+
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",


### PR DESCRIPTION
The first time a world is loaded on single player, the tags inside the registries are not populated, resulting in ingredient entries not being transferred properly while loading (they come out as empty lists when received).

This fix uses an Entry interface inside Ingredient, and converts the serializable ingredient entries to use this. I utilized the mechanisms they have for transferring tag ingredients before the tags are populated and this seems to fix the issues I was having.