### PR TITLE
Move identifier aliasing from Apoli

### DIFF
--- a/src/main/java/io/github/apace100/calio/data/SerializableDataType.java
+++ b/src/main/java/io/github/apace100/calio/data/SerializableDataType.java
@@ -12,6 +12,7 @@ import io.github.apace100.calio.mixin.WeightedListEntryAccessor;
 import io.github.apace100.calio.util.ArgumentWrapper;
 import io.github.apace100.calio.util.DynamicIdentifier;
 import io.github.apace100.calio.util.TagLike;
+import io.github.apace100.calio.util.IdentifierAlias;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.Registry;
@@ -21,6 +22,7 @@ import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.collection.WeightedList;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -214,24 +216,27 @@ public class SerializableDataType<T> {
     }
 
     public static <T> SerializableDataType<T> registry(Class<T> dataClass, Registry<T> registry, String defaultNamespace, boolean showPossibleValues) {
-        return registry(dataClass, registry, defaultNamespace, (reg, id) -> {
+        return registry(dataClass, registry, defaultNamespace, null, (reg, id) -> {
             String possibleValues = showPossibleValues ? " Expected value to be any of " + String.join(", ", reg.getIds().stream().map(Identifier::toString).toList()) : "";
             return new RuntimeException("Type \"%s\" is not registered in registry \"%s\".%s".formatted(id, registry.getKey().getValue(), possibleValues));
         });
     }
 
     public static <T> SerializableDataType<T> registry(Class<T> dataClass, Registry<T> registry, BiFunction<Registry<T>, Identifier, RuntimeException> exception) {
-        return registry(dataClass, registry, Identifier.DEFAULT_NAMESPACE, exception);
+        return registry(dataClass, registry, Identifier.DEFAULT_NAMESPACE, null, exception);
     }
 
-    public static <T> SerializableDataType<T> registry(Class<T> dataClass, Registry<T> registry, String defaultNamespace, BiFunction<Registry<T>, Identifier, RuntimeException> exception) {
+    public static <T> SerializableDataType<T> registry(Class<T> dataClass, Registry<T> registry, String defaultNamespace, @Nullable IdentifierAlias aliases, BiFunction<Registry<T>, Identifier, RuntimeException> exception) {
         return wrap(
             dataClass,
             SerializableDataTypes.STRING,
-            t -> Objects.requireNonNull(registry.getId(t)).toString(),
+            t ->
+                Objects.requireNonNull(registry.getId(t)).toString(),
             idString -> {
                 Identifier id = DynamicIdentifier.of(idString, defaultNamespace);
-                return registry.getOrEmpty(id).orElseThrow(() -> exception.apply(registry, id));
+                return registry
+                    .getOrEmpty(aliases == null ? id : aliases.resolveAlias(id, registry::containsId))
+                    .orElseThrow(() -> exception.apply(registry, id));
             }
         );
     }

--- a/src/main/java/io/github/apace100/calio/util/IdentifierAlias.java
+++ b/src/main/java/io/github/apace100/calio/util/IdentifierAlias.java
@@ -1,0 +1,224 @@
+package io.github.apace100.calio.util;
+
+import io.github.apace100.calio.Calio;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ *  <p>A utility class used for adding aliases to identifiers and/or its namespace and/or path, which can be used for substituting an
+ *  {@link Identifier} (or its namespace and/or path).</p>
+ *
+ *  <p>This can be used in cases, such as serializing objects with {@linkplain com.mojang.serialization.Codec#dispatchMap(Function, Function) codec map dispatcher}
+ *  (usually queried via {@link Registry#getCodec()}.)</p>
+ */
+public class IdentifierAlias {
+
+    protected static final Function<Identifier, RuntimeException> NO_ALIAS_EXCEPTION = id -> new RuntimeException("Tried resolving non-existent alias for id \"" + id + "\"");
+    public static final IdentifierAlias GLOBAL = new IdentifierAlias();
+
+    protected final Map<Identifier, Identifier> identifierAliases = new HashMap<>();
+    protected final Map<String, String> namespaceAliases = new HashMap<>();
+    protected final Map<String, String> pathAliases = new HashMap<>();
+
+    public void addAlias(Identifier fromId, Identifier toId) {
+
+        if (identifierAliases.containsKey(fromId)) {
+            Identifier owner = identifierAliases.get(fromId);
+            Calio.LOGGER.error("Couldn't add alias \"{}\" to identifier \"{}\": {}", fromId, toId, (owner.equals(toId) ? "it's already defined!" : "it's already defined for a different identifier: \"" + owner + "\""));
+        }
+
+        else {
+            identifierAliases.put(fromId, toId);
+        }
+
+    }
+
+    public void addNamespaceAlias(String fromNamespace, String toNamespace) {
+
+        if (namespaceAliases.containsKey(fromNamespace)) {
+            String owner = namespaceAliases.get(fromNamespace);
+            Calio.LOGGER.error("Couldn't add alias \"{}\" to namespace \"{}\": {}", fromNamespace, toNamespace, (owner.equals(toNamespace) ? "it's already defined!" : "it's already defined for a different namespace: \"" + owner + "\""));
+        }
+
+        else {
+            namespaceAliases.put(fromNamespace, toNamespace);
+        }
+
+    }
+
+    public void addPathAlias(String fromPath, String toPath) {
+
+        if (pathAliases.containsKey(fromPath)) {
+            String owner = pathAliases.get(fromPath);
+            Calio.LOGGER.error("Couldn't add alias \"{}\" to path \"{}\": {}", fromPath, toPath, (owner.equals(toPath) ? "it's already defined!" : "it's already defined for a different path: \"" + owner + "\""));
+        }
+
+        else {
+            pathAliases.put(fromPath, toPath);
+        }
+
+    }
+
+    public boolean hasIdentifierAlias(Identifier id) {
+        return identifierAliases.containsKey(id)
+            || (this != GLOBAL && GLOBAL.hasIdentifierAlias(id));
+    }
+
+    public boolean hasNamespaceAlias(Identifier id) {
+        String namespace = id.getNamespace();
+        return namespaceAliases.containsKey(namespace)
+            || (this != GLOBAL && GLOBAL.hasNamespaceAlias(id));
+    }
+
+    public boolean hasPathAlias(Identifier id) {
+        String path = id.getPath();
+        return pathAliases.containsKey(path)
+            || (this != GLOBAL && GLOBAL.hasPathAlias(id));
+    }
+
+    public boolean hasAlias(Identifier id) {
+        return this.hasIdentifierAlias(id)
+            || this.hasNamespaceAlias(id)
+            || this.hasPathAlias(id);
+    }
+
+    public Identifier resolveIdentifierAlias(Identifier id, boolean strict) {
+
+        if (identifierAliases.containsKey(id)) {
+            return identifierAliases.get(id);
+        }
+
+        else if (this != GLOBAL) {
+            return GLOBAL.resolveIdentifierAlias(id, strict);
+        }
+
+        else if (strict) {
+            throw NO_ALIAS_EXCEPTION.apply(id);
+        }
+
+        else {
+            return id;
+        }
+
+    }
+
+    public Identifier resolveNamespaceAlias(Identifier id, boolean strict) {
+
+        String namespace = id.getNamespace();
+        if (namespaceAliases.containsKey(namespace)) {
+            return Identifier.of(namespaceAliases.get(namespace), id.getPath());
+        }
+
+        else if (this != GLOBAL) {
+            return GLOBAL.resolveNamespaceAlias(id, strict);
+        }
+
+        else if (strict) {
+            throw NO_ALIAS_EXCEPTION.apply(id);
+        }
+
+        else {
+            return id;
+        }
+
+    }
+
+    public Identifier resolvePathAlias(Identifier id, boolean strict) {
+
+        String path = id.getPath();
+        if (pathAliases.containsKey(path)) {
+            return Identifier.of(id.getNamespace(), pathAliases.get(path));
+        }
+
+        else if (this != GLOBAL) {
+            return GLOBAL.resolvePathAlias(id, strict);
+        }
+
+        else if (strict) {
+            throw NO_ALIAS_EXCEPTION.apply(id);
+        }
+
+        else {
+            return id;
+        }
+
+    }
+
+    public Identifier resolveAlias(Identifier id, Predicate<Identifier> untilPredicate) {
+
+        Identifier aliasedId;
+        for (Resolver resolver : Resolver.values()) {
+
+            aliasedId = resolver.apply(this, id);
+
+            if (untilPredicate.test(aliasedId)) {
+                return aliasedId;
+            }
+
+        }
+
+        return id;
+
+    }
+
+    public enum Resolver implements BiFunction<IdentifierAlias, Identifier, Identifier> {
+
+        NO_OP {
+
+            @Override
+            public Identifier apply(IdentifierAlias aliases, Identifier id) {
+                return id;
+            }
+
+        },
+
+        IDENTIFIER {
+
+            @Override
+            public Identifier apply(IdentifierAlias aliases, Identifier id) {
+                return aliases.resolveIdentifierAlias(id, false);
+            }
+
+        },
+
+        NAMESPACE {
+
+            @Override
+            public Identifier apply(IdentifierAlias aliases, Identifier id) {
+                return aliases.resolveNamespaceAlias(id, false);
+            }
+
+        },
+
+        PATH {
+
+            @Override
+            public Identifier apply(IdentifierAlias aliases, Identifier id) {
+                return aliases.resolvePathAlias(id, false);
+            }
+
+        },
+
+        NAMESPACE_AND_PATH {
+
+            @Override
+            public Identifier apply(IdentifierAlias aliases, Identifier id) {
+
+                String aliasedNamespace = aliases.resolveNamespaceAlias(id, false).getNamespace();
+                String aliasedPath = aliases.resolvePathAlias(id, false).getPath();
+
+                return Identifier.of(aliasedNamespace, aliasedPath);
+
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR moves the identifier aliasing system from Apoli to Calio. This also refactors how the aliasing system works, which has now been separated into two parts: "local", where aliases are contained per instance of the `IdentifierAlias` class, and "global", where aliases are contained in a singleton instance